### PR TITLE
Restore canonicalization of `bin` argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "sub"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "clap",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sub"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Juan Ibiapina <juanibiapina@gmail.com>"]
 edition = "2018"
 

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
 with pkgs;
 rustPlatform.buildRustPackage rec {
   name = "sub-${version}";
-  version = "0.8.0";
+  version = "0.8.1";
   src = ./.;
 
   cargoLock = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,8 @@ fn parse_cli_args() -> Args {
                 let mut path = args
                     .get_one::<PathBuf>("bin")
                     .expect("Either `bin` or `absolute` is required")
+                    .canonicalize()
+                    .expect("Invalid `bin` path")
                     .clone();
                 path.pop(); // remove bin name
                 if let Some(relative) = args.get_one::<PathBuf>("relative") {


### PR DESCRIPTION
I don't know exactly why this is needed, but it fails without this in my
setup.