### PR TITLE
Fix autocompletion on executables generated by the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,9 +69,9 @@
                   read -cA words
 
                   if [ "\''${#words}" -eq 2 ]; then
-                    completions="\$(${cmd} completions)"
+                    completions="\$(${cmd} --completions)"
                   else
-                    completions="\$(${cmd} completions "\''${words[@]:1:-1}")"
+                    completions="\$(${cmd} --completions "\''${words[@]:1:-1}")"
                   fi
 
                   reply=("\''${(ps:\n:)completions}")


### PR DESCRIPTION
After the change from a `completions` command to a `--completions` flag, the flake setup broke. This PR should fix it.