### PR TITLE
Add coverage target for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,35 @@
 integration: build test
 	bats integration
 
+# Find LLVM tools - check common locations (can override with LLVM_BIN=/path/to/bin)
+LLVM_BIN ?= $(shell \
+	for path in \
+		"$$(which llvm-profdata 2>/dev/null | xargs dirname 2>/dev/null)" \
+		"/opt/homebrew/opt/llvm/bin" \
+		"/usr/local/opt/llvm/bin" \
+		"/usr/lib/llvm-18/bin" \
+		"/usr/lib/llvm-17/bin" \
+		"/usr/lib/llvm-16/bin" \
+		"/usr/lib/llvm-15/bin" \
+		"/usr/bin"; do \
+		if [ -x "$$path/llvm-profdata" ] && [ -x "$$path/llvm-cov" ]; then \
+			echo "$$path"; \
+			break; \
+		fi; \
+	done)
+
+.PHONY: coverage
+coverage: test
+ifndef LLVM_BIN
+	$(error LLVM tools not found. Install LLVM or set LLVM_BIN manually)
+endif
+	RUSTFLAGS="-C instrument-coverage" cargo build
+	rm -f *.profraw
+	-LLVM_PROFILE_FILE="sub-%p-%m.profraw" bats integration/
+	$(LLVM_BIN)/llvm-profdata merge -sparse *.profraw -o sub.profdata
+	$(LLVM_BIN)/llvm-cov report ./target/debug/sub --instr-profile=sub.profdata --ignore-filename-regex='/.cargo/registry|rustc'
+	rm -f *.profraw sub.profdata
+
 .PHONY: build
 build:
 	cargo build


### PR DESCRIPTION
Adds a `make coverage` target that runs BATS integration tests with LLVM source-based coverage instrumentation.

## What it does

1. Runs unit tests
2. Builds with `-C instrument-coverage`
3. Runs BATS integration tests (continues even if some fail)
4. Generates coverage report via `llvm-cov`
5. Cleans up intermediate files

## Example output

```
Filename                      Regions    Missed Regions     Cover   Functions  Executed       Lines     Cover
--------------------------------------------------------------------------------------------------------------
commands/directory.rs             188                12    93.62%          13    92.31%         114    92.98%
commands/file.rs                  185                14    92.43%          10    90.00%          91    85.71%
commands/mod.rs                    72                 1    98.61%           1   100.00%          37    97.30%
config.rs                         112                14    87.50%           4   100.00%          49    79.59%
main.rs                           273                56    79.49%           9    77.78%         155    78.06%
parser.rs                         140                 5    96.43%           3   100.00%          82    93.90%
usage.rs                          449                 7    98.44%          32   100.00%         177    97.74%
--------------------------------------------------------------------------------------------------------------
TOTAL                            1419               109    92.32%          72    94.44%         705    89.36%
```

## LLVM detection

Auto-detects LLVM tools from:
- `llvm-profdata` in PATH
- Homebrew on Apple Silicon (`/opt/homebrew/opt/llvm/bin`)
- Homebrew on Intel Mac (`/usr/local/opt/llvm/bin`)
- Linux system LLVM (`/usr/lib/llvm-{18,17,16,15}/bin`)
- System binaries (`/usr/bin`)

Can be overridden: `make coverage LLVM_BIN=/custom/path`