### PR TITLE
ci: replace deprecated actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,11 +24,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install rust stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-          toolchain: stable
-          override: true
-          target: x86_64-unknown-linux-gnu
+          targets: x86_64-unknown-linux-gnu
     - name: Create Artifact
       run: |
         cargo build --target x86_64-unknown-linux-gnu --release
@@ -50,11 +48,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install rust stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-          toolchain: stable
-          override: true
-          target: aarch64-apple-darwin
+          targets: aarch64-apple-darwin
     - name: Create Artifact
       run: |
         cargo build --target aarch64-apple-darwin --release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,7 @@ jobs:
       with:
         submodules: recursive
     - name: Install rust stable
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Run linter
       run: make lint
     - name: Run tests


### PR DESCRIPTION
Replaces the archived `actions-rs/toolchain@v1` (last updated June 2023) with `dtolnay/rust-toolchain@stable` across all CI workflows.

**Changes:**
- `test.yml`: Replaced toolchain action, removed unnecessary `override` parameter
- `publish.yml`: Replaced toolchain action in both Linux and macOS publish jobs, renamed `target` to `targets` to match the new action's interface

`dtolnay/rust-toolchain` is actively maintained by [David Tolnay](https://github.com/dtolnay), one of the most prolific Rust ecosystem maintainers.

Closes #30